### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/112/579/142/9/1125791429.geojson
+++ b/data/112/579/142/9/1125791429.geojson
@@ -305,6 +305,9 @@
     },
     "wof:country":"LB",
     "wof:created":1497290877,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"d51d276904daf4471a307cdcaa449534",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
         }
     ],
     "wof:id":1125791429,
-    "wof:lastmodified":1566594005,
+    "wof:lastmodified":1582318499,
     "wof:name":"Tripoli",
     "wof:parent_id":1108691443,
     "wof:placetype":"locality",

--- a/data/421/171/405/421171405.geojson
+++ b/data/421/171/405/421171405.geojson
@@ -153,6 +153,9 @@
     },
     "wof:country":"LB",
     "wof:created":1459008892,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa79518c7f8718efa2e9822dc6fa16f1",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":421171405,
-    "wof:lastmodified":1566594003,
+    "wof:lastmodified":1582318498,
     "wof:name":"Baalbek",
     "wof:parent_id":1377074353,
     "wof:placetype":"county",

--- a/data/421/172/015/421172015.geojson
+++ b/data/421/172/015/421172015.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"LB",
     "wof:created":1459008916,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb052413ca8848644eb01061825ca507",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421172015,
-    "wof:lastmodified":1566593997,
+    "wof:lastmodified":1582318498,
     "wof:name":"Kesrwane",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/172/017/421172017.geojson
+++ b/data/421/172/017/421172017.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"LB",
     "wof:created":1459008916,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9c10cbd6e59fcb1ddb1bd6b531f1568",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":421172017,
-    "wof:lastmodified":1566593997,
+    "wof:lastmodified":1582318498,
     "wof:name":"Zahle",
     "wof:parent_id":1377074351,
     "wof:placetype":"county",

--- a/data/421/173/359/421173359.geojson
+++ b/data/421/173/359/421173359.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"LB",
     "wof:created":1459008980,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc27a757d9dbaf2f06751cc38681645e",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421173359,
-    "wof:lastmodified":1566593997,
+    "wof:lastmodified":1582318498,
     "wof:name":"West Bekaa",
     "wof:parent_id":1377074351,
     "wof:placetype":"county",

--- a/data/421/194/845/421194845.geojson
+++ b/data/421/194/845/421194845.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"LB",
     "wof:created":1459009821,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93804c8a23e525a2b8a962d522d31a11",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421194845,
-    "wof:lastmodified":1566593995,
+    "wof:lastmodified":1582318498,
     "wof:name":"Jbeil",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/202/301/421202301.geojson
+++ b/data/421/202/301/421202301.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"LB",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5515d5cef62a94e133b41c9e84509ab",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421202301,
-    "wof:lastmodified":1566593996,
+    "wof:lastmodified":1582318498,
     "wof:name":"Baabda",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/204/111/421204111.geojson
+++ b/data/421/204/111/421204111.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"LB",
     "wof:created":1459010174,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7117b03b7306885a3da972d77acb6a3f",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421204111,
-    "wof:lastmodified":1566593996,
+    "wof:lastmodified":1582318498,
     "wof:name":"El Batroun",
     "wof:parent_id":1377074355,
     "wof:placetype":"county",

--- a/data/856/325/33/85632533.geojson
+++ b/data/856/325/33/85632533.geojson
@@ -1041,6 +1041,12 @@
     },
     "wof:country":"LB",
     "wof:country_alpha3":"LBN",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"c596403385e0f1fc6ec47fb7bf04ea1b",
     "wof:hierarchy":[
         {
@@ -1055,7 +1061,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"Lebanon",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/734/79/85673479.geojson
+++ b/data/856/734/79/85673479.geojson
@@ -128,6 +128,9 @@
         "qs:id":1135130
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b6775a3270788b116f67e2d820960ed9",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1551727682,
+    "wof:lastmodified":1582318495,
     "wof:name":"Beqaa",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/83/85673483.geojson
+++ b/data/856/734/83/85673483.geojson
@@ -127,6 +127,9 @@
         "qs:id":1135132
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d50d9f1c11298318614d228fda488dc",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1551727687,
+    "wof:lastmodified":1582318495,
     "wof:name":"North Lebanon",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/87/85673487.geojson
+++ b/data/856/734/87/85673487.geojson
@@ -579,6 +579,9 @@
         890442383
     ],
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0eaba196377b9ebb35b06c7a172804af",
     "wof:hierarchy":[
         {
@@ -594,7 +597,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566593819,
+    "wof:lastmodified":1582318495,
     "wof:name":"Beirut",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/91/85673491.geojson
+++ b/data/856/734/91/85673491.geojson
@@ -282,6 +282,9 @@
         "unlc:id":"LB-JL"
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"153102beba100b17bafca8505f5aae8e",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566593820,
+    "wof:lastmodified":1582318495,
     "wof:name":"Mount Lebanon",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/95/85673495.geojson
+++ b/data/856/734/95/85673495.geojson
@@ -209,6 +209,9 @@
         "qs_pg:id":996715
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13c511619e1ca666689a457f1aa67075",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566593819,
+    "wof:lastmodified":1582318495,
     "wof:name":"Nabatieh",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/99/85673499.geojson
+++ b/data/856/734/99/85673499.geojson
@@ -275,6 +275,9 @@
         "qs_pg:id":1135131
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"051e3ecadd90c45e2be9f1f173f08de3",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566593820,
+    "wof:lastmodified":1582318495,
     "wof:name":"South Lebanon",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/859/030/43/85903043.geojson
+++ b/data/859/030/43/85903043.geojson
@@ -85,6 +85,10 @@
         "qs_pg:id":1119734
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f3311e164d07f58d300d3593505099f",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"\u0627\u0644\u0628\u0627\u0634\u0648\u0631\u0629",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/45/85903045.geojson
+++ b/data/859/030/45/85903045.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1119735
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"80935aecedcfa1e69594e79840aca792",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"\u0627\u0644\u062d\u0645\u0631\u0627",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/49/85903049.geojson
+++ b/data/859/030/49/85903049.geojson
@@ -79,6 +79,9 @@
         "qs:id":249536
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfae8362d8dc8d274697006fe62336c6",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379375,
+    "wof:lastmodified":1582318493,
     "wof:name":"Al Mudawwar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/51/85903051.geojson
+++ b/data/859/030/51/85903051.geojson
@@ -99,6 +99,9 @@
         "qs_pg:id":900086
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf256ce18ee05d1e6f24b8c33f2851e2",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"Al Qan\u0163\u0101r\u012b",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/57/85903057.geojson
+++ b/data/859/030/57/85903057.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1317460
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2495c07b388d8d0b3c1bd648e31d62e3",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"Ra's An Nab\u2019an",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/59/85903059.geojson
+++ b/data/859/030/59/85903059.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":983997
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55acd672bc057e37c7858aff9a80d905",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"Tall Az Za\u2019tar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/31/85906931.geojson
+++ b/data/859/069/31/85906931.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Ras Beirut"
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"acbf95bf28a51daf01b553c011a24499",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"Ras Beirut",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/33/85906933.geojson
+++ b/data/859/069/33/85906933.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1262788
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"468033b2258a6364e3ed93b5dd65b112",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u0627\u0644\u0645\u0646\u0627\u0631\u0629",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/37/85906937.geojson
+++ b/data/859/069/37/85906937.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":466999
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1e1d7799a0098130bcba99ec4174a3d",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u062c\u0646\u0628\u0644\u0627\u0637",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/39/85906939.geojson
+++ b/data/859/069/39/85906939.geojson
@@ -79,6 +79,9 @@
         "qs:id":230056
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a1e673ecc382f94f24b50d84b4378b7",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379375,
+    "wof:lastmodified":1582318494,
     "wof:name":"Kantari",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/41/85906941.geojson
+++ b/data/859/069/41/85906941.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1187504
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"48594dff3f4da17178e01faba514f889",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u0627\u0644\u0631\u0648\u0634\u0629",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/43/85906943.geojson
+++ b/data/859/069/43/85906943.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1262789
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e9fae0178f637dd0b49b432d2e2c2b9",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"Patriarcat",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/45/85906945.geojson
+++ b/data/859/069/45/85906945.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1262793
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c74fc60a6f6d830d6402390c22ae226b",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u0631\u0645\u0644\u0629 \u0627\u0644\u0628\u064a\u0636\u0627\u0621",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/47/85906947.geojson
+++ b/data/859/069/47/85906947.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":990003
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f11678f8aefacfeb735b9eef77c795a",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u0645\u0627\u0631 \u0627\u0644\u064a\u0627\u0633",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/49/85906949.geojson
+++ b/data/859/069/49/85906949.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":19643
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0af46f88b4ad4051e9653c89e719e986",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u062e\u0636\u0631",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/51/85906951.geojson
+++ b/data/859/069/51/85906951.geojson
@@ -193,6 +193,9 @@
         "wd:id":"Q228896"
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aaf59c688c6171112ddf680bbe6a73b4",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318493,
     "wof:name":"Salome",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/55/85906955.geojson
+++ b/data/859/069/55/85906955.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":237758
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"22ee6b2372e372e88619a2fbe822e6ef",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u062c\u0633\u0631 \u0627\u0644\u0628\u0627\u0634\u0627",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/57/85906957.geojson
+++ b/data/859/069/57/85906957.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":502175
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e9025f8a02103a429f8ac6260ee3067",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"Ghobeiri",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/59/85906959.geojson
+++ b/data/859/069/59/85906959.geojson
@@ -80,6 +80,10 @@
         "wd:id":"Q23438253"
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"783d4f130371204845ac74e0a81f0d59",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"Badaro",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/61/85906961.geojson
+++ b/data/859/069/61/85906961.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1065116
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c94c67873ca1fd47d6f607d39d6b9765",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"\u0627\u0644\u0633\u064a\u0648\u0641\u064a",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/63/85906963.geojson
+++ b/data/859/069/63/85906963.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":366749
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"707bcedff8f4b13157c269f24f4db2ee",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u0627\u0644\u062c\u0639\u064a\u062a\u0627\u0648\u064a",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/65/85906965.geojson
+++ b/data/859/069/65/85906965.geojson
@@ -93,6 +93,10 @@
         "wd:id":"Q4704645"
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ef923020ac4db38fa160548bbbc64c2",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"Qobaiyat",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/67/85906967.geojson
+++ b/data/859/069/67/85906967.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1184295
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"19cecef3f8d78f599b65bdc9c5593948",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318493,
     "wof:name":"Remeil",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/69/85906969.geojson
+++ b/data/859/069/69/85906969.geojson
@@ -89,6 +89,10 @@
         "wd:id":"Q2944781"
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5dcf89418622f9e1a9996c192d51fdc6",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593816,
+    "wof:lastmodified":1582318493,
     "wof:name":"Beirut Central District",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/73/85906973.geojson
+++ b/data/859/069/73/85906973.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1118664
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a80861580f720da2de8099b48277e85d",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u0628\u0631\u062c \u0627\u0628\u064a \u062d\u064a\u062f\u0631",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/75/85906975.geojson
+++ b/data/859/069/75/85906975.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":234040
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8246a5966a7fb452d0347a14e9107025",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593817,
+    "wof:lastmodified":1582318494,
     "wof:name":"Yessoueiye",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/77/85906977.geojson
+++ b/data/859/069/77/85906977.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":996621
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d70df9174ce4e454a4788c18d06b0688",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"\u0641\u0631\u0646 \u0627\u0644\u062d\u0627\u064a\u0643",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/79/85906979.geojson
+++ b/data/859/069/79/85906979.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1121102
     },
     "wof:country":"LB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81391c770a26aecca10a427a84b51b54",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566593818,
+    "wof:lastmodified":1582318494,
     "wof:name":"Jall Ed Did",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/442/383/890442383.geojson
+++ b/data/890/442/383/890442383.geojson
@@ -662,6 +662,9 @@
     ],
     "wof:country":"LB",
     "wof:created":1469052360,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"0eaba196377b9ebb35b06c7a172804af",
     "wof:hierarchy":[
         {
@@ -672,7 +675,7 @@
         }
     ],
     "wof:id":890442383,
-    "wof:lastmodified":1566594004,
+    "wof:lastmodified":1582318499,
     "wof:name":"Beirut",
     "wof:parent_id":85673487,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.