### PR TITLE
Name updates

### DIFF
--- a/data/856/325/33/85632533.geojson
+++ b/data/856/325/33/85632533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.997028,
-    "geom:area_square_m":10229929019.421522,
+    "geom:area_square_m":10229928695.188868,
     "geom:bbox":"35.103668,33.055026,36.62372,34.69208",
     "geom:latitude":33.921502,
     "geom:longitude":35.893878,
@@ -72,6 +72,9 @@
     "name:arg_x_variant":[
         "Libano"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0648\u0628\u0646\u0627\u0646"
+    ],
     "name:arz_x_preferred":[
         "\u0644\u0628\u0646\u0627\u0646"
     ],
@@ -98,6 +101,9 @@
     ],
     "name:bam_x_variant":[
         "Liba\u014b"
+    ],
+    "name:ban_x_preferred":[
+        "L\u00e9banon"
     ],
     "name:bar_x_preferred":[
         "Libanon"
@@ -192,6 +198,12 @@
     "name:dan_x_preferred":[
         "Libanon"
     ],
+    "name:deu_at_x_preferred":[
+        "Libanon"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Libanon"
+    ],
     "name:deu_x_preferred":[
         "Libanon"
     ],
@@ -218,6 +230,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039b\u03af\u03b2\u03b1\u03bd\u03bf\u03c2"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Lebanon"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Lebanon"
     ],
     "name:eng_x_preferred":[
         "Lebanon"
@@ -284,6 +302,9 @@
     ],
     "name:gag_x_preferred":[
         "Livan"
+    ],
+    "name:gcr_x_preferred":[
+        "Liban"
     ],
     "name:gla_x_preferred":[
         "Leabanon"
@@ -552,6 +573,9 @@
     "name:mon_x_preferred":[
         "\u041b\u0438\u0432\u0430\u043d"
     ],
+    "name:mri_x_preferred":[
+        "Repanona"
+    ],
     "name:msa_x_preferred":[
         "Lubnan"
     ],
@@ -662,6 +686,9 @@
     "name:pol_x_preferred":[
         "Liban"
     ],
+    "name:por_br_x_preferred":[
+        "L\u00edbano"
+    ],
     "name:por_x_preferred":[
         "L\u00edbano"
     ],
@@ -728,6 +755,9 @@
     "name:sna_x_preferred":[
         "Lebanon"
     ],
+    "name:snd_x_preferred":[
+        "\u0644\u0628\u0646\u0627\u0646"
+    ],
     "name:som_x_preferred":[
         "Lubnaan"
     ],
@@ -745,6 +775,12 @@
     ],
     "name:srd_x_preferred":[
         "L\u00ecbanu"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041b\u0438\u0431\u0430\u043d"
+    ],
+    "name:srp_el_x_preferred":[
+        "Liban"
     ],
     "name:srp_x_preferred":[
         "\u041b\u0438\u0431\u0430\u043d"
@@ -766,6 +802,9 @@
     ],
     "name:szl_x_preferred":[
         "Liban"
+    ],
+    "name:szy_x_preferred":[
+        "Lebanon"
     ],
     "name:tam_x_preferred":[
         "\u0bb2\u0bc6\u0baa\u0ba9\u0bbe\u0ba9\u0bcd"
@@ -898,8 +937,17 @@
     "name:zha_x_preferred":[
         "Lebanon"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u9ece\u5df4\u5ae9"
+    ],
     "name:zho_min_nan_x_preferred":[
         "L\u012b-pa-l\u00f9n"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u9ece\u5df4\u5ae9"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u9ece\u5df4\u5ae9"
     ],
     "name:zho_x_preferred":[
         "\u9ece\u5df4\u5ae9"
@@ -1062,7 +1110,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1583797380,
+    "wof:lastmodified":1587428236,
     "wof:name":"Lebanon",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.