### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/137/707/436/1/1377074361.geojson
+++ b/data/137/707/436/1/1377074361.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u0627\u0632\u0645\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hazmiyeh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":1377074361,
-    "wof:lastmodified":1566593983,
-    "wof:name":"\u0627\u0644\u062d\u0627\u0632\u0645\u064a\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Hazmiyeh",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/137/707/436/1/1377074361.geojson
+++ b/data/137/707/436/1/1377074361.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1377074361,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Hazmiyeh",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/137/707/436/3/1377074363.geojson
+++ b/data/137/707/436/3/1377074363.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.8248705,34.439123,35.8248705,34.439123",
+    "geom:bbox":"35.824871,34.439123,35.824871,34.439123",
     "geom:latitude":34.439123,
     "geom:longitude":35.824871,
     "iso:country":"LB",
@@ -42,11 +42,11 @@
     "qs:woe_id":1959661,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        1377074355,
         102191569,
         85632533,
+        1108691443,
         1125791429,
-        1108691443
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009662,
-    "wof:geomhash":"d34d094fbfa0d1b9a064bea5eaf5655e",
+    "wof:geomhash":"813040e19f1eb1f3d29a6e3b2d44fc20",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1377074363,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mina",
     "wof:parent_id":1125791429,
     "wof:placetype":"neighbourhood",
@@ -79,10 +79,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    35.8248705,
+    35.824871,
     34.439123,
-    35.8248705,
+    35.824871,
     34.439123
 ],
-  "geometry": {"coordinates":[35.8248705,34.439123],"type":"Point"}
+  "geometry": {"coordinates":[35.824871,34.439123],"type":"Point"}
 }

--- a/data/137/707/436/3/1377074363.geojson
+++ b/data/137/707/436/3/1377074363.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u064a\u0646\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mina"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1377074363,
-    "wof:lastmodified":1566593983,
-    "wof:name":"\u0627\u0644\u0645\u064a\u0646\u0627\u0621",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mina",
     "wof:parent_id":1125791429,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/166/857/421166857.geojson
+++ b/data/421/166/857/421166857.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0631 \u0627\u0644\u064a\u0627\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Bar Elias"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421166857,
-    "wof:lastmodified":1566593995,
-    "wof:name":"\u0628\u0631 \u0627\u0644\u064a\u0627\u0633",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bar Elias",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/166/857/421166857.geojson
+++ b/data/421/166/857/421166857.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074351,
-        421172017
+        421172017,
+        1377074351
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421166857,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Bar Elias",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",

--- a/data/421/168/321/421168321.geojson
+++ b/data/421/168/321/421168321.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691419
+        1108691419,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421168321,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Beit Ed Dine",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",

--- a/data/421/168/321/421168321.geojson
+++ b/data/421/168/321/421168321.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u064a\u062a \u0627\u0644\u062f\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Beit Ed Dine"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421168321,
-    "wof:lastmodified":1566593994,
-    "wof:name":"\u0628\u064a\u062a \u0627\u0644\u062f\u064a\u0646",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Beit Ed Dine",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/170/465/421170465.geojson
+++ b/data/421/170/465/421170465.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Janneh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170465,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u062c\u0646\u0629",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Janneh",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/170/465/421170465.geojson
+++ b/data/421/170/465/421170465.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.833087,34.0950065,35.833087,34.0950065",
+    "geom:bbox":"35.833087,34.095006,35.833087,34.095006",
     "geom:latitude":34.095006,
     "geom:longitude":35.833087,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421194845
+        421194845,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459008854,
-    "wof:geomhash":"6ad071cd62b6031a7e001e46d9a953ed",
+    "wof:geomhash":"c06b33d42872afe3e65cc1ec1a7ef1ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170465,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Janneh",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     35.833087,
-    34.0950065,
+    34.095006,
     35.833087,
-    34.0950065
+    34.095006
 ],
-  "geometry": {"coordinates":[35.833087,34.0950065],"type":"Point"}
+  "geometry": {"coordinates":[35.833087,34.095006],"type":"Point"}
 }

--- a/data/421/170/475/421170475.geojson
+++ b/data/421/170/475/421170475.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673495,
-        1108691437
+        1108691437,
+        85673495
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170475,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Marjayoun",
     "wof:parent_id":1108691437,
     "wof:placetype":"locality",

--- a/data/421/170/475/421170475.geojson
+++ b/data/421/170/475/421170475.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u062c\u0639\u064a\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Marjayoun"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170475,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u0645\u0631\u062c\u0639\u064a\u0648\u0646",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Marjayoun",
     "wof:parent_id":1108691437,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/170/477/421170477.geojson
+++ b/data/421/170/477/421170477.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.482492,33.4171855,35.482492,33.4171855",
+    "geom:bbox":"35.482492,33.417186,35.482492,33.417186",
     "geom:latitude":33.417186,
     "geom:longitude":35.482492,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673495,
-        1108691429
+        1108691429,
+        85673495
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459008855,
-    "wof:geomhash":"6cbe28bcf5926b060cf960ec44f2e8da",
+    "wof:geomhash":"1e29e86027d8b512ff35f2858f583f06",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170477,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Habbouch",
     "wof:parent_id":1108691429,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     35.482492,
-    33.4171855,
+    33.417186,
     35.482492,
-    33.4171855
+    33.417186
 ],
-  "geometry": {"coordinates":[35.482492,33.4171855],"type":"Point"}
+  "geometry": {"coordinates":[35.482492,33.417186],"type":"Point"}
 }

--- a/data/421/170/477/421170477.geojson
+++ b/data/421/170/477/421170477.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u0628\u0648\u0634"
+    ],
+    "name:eng_x_preferred":[
+        "Habbouch"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170477,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u062d\u0628\u0648\u0634",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Habbouch",
     "wof:parent_id":1108691429,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/170/531/421170531.geojson
+++ b/data/421/170/531/421170531.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0632\u0631\u0639\u0629 \u0627\u0644\u0633\u064a\u0627\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Mazraat Es Siyad"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170531,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u0645\u0632\u0631\u0639\u0629 \u0627\u0644\u0633\u064a\u0627\u062f",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Mazraat Es Siyad",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/170/531/421170531.geojson
+++ b/data/421/170/531/421170531.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.8564355,34.113612,35.8564355,34.113612",
+    "geom:bbox":"35.856436,34.113612,35.856436,34.113612",
     "geom:latitude":34.113612,
     "geom:longitude":35.856436,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421194845
+        421194845,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459008857,
-    "wof:geomhash":"eddc5c7e76cdce9da23cfd1b4a4999e8",
+    "wof:geomhash":"2f92bcd2ef962e8e9668402ca75e80f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170531,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Mazraat Es Siyad",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    35.8564355,
+    35.856436,
     34.113612,
-    35.8564355,
+    35.856436,
     34.113612
 ],
-  "geometry": {"coordinates":[35.8564355,34.113612],"type":"Point"}
+  "geometry": {"coordinates":[35.856436,34.113612],"type":"Point"}
 }

--- a/data/421/171/329/421171329.geojson
+++ b/data/421/171/329/421171329.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0637\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Wata"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421171329,
-    "wof:lastmodified":1566594003,
-    "wof:name":"\u0648\u0637\u0649",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Wata",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/171/329/421171329.geojson
+++ b/data/421/171/329/421171329.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421171329,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423094,
     "wof:name":"Wata",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/173/007/421173007.geojson
+++ b/data/421/173/007/421173007.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074353,
-        421171405
+        421171405,
+        1377074353
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421173007,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Baalbek",
     "wof:parent_id":421171405,
     "wof:placetype":"locality",

--- a/data/421/173/007/421173007.geojson
+++ b/data/421/173/007/421173007.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0639\u0644\u0628\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Baalbek"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421173007,
-    "wof:lastmodified":1566593997,
-    "wof:name":"\u0628\u0639\u0644\u0628\u0643",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Baalbek",
     "wof:parent_id":421171405,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/175/231/421175231.geojson
+++ b/data/421/175/231/421175231.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u064a\u0631\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Beirut"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -56,8 +62,8 @@
         }
     ],
     "wof:id":421175231,
-    "wof:lastmodified":1537229397,
-    "wof:name":"\u0628\u064a\u0631\u0648\u062a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Beirut",
     "wof:parent_id":1108691413,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/175/231/421175231.geojson
+++ b/data/421/175/231/421175231.geojson
@@ -41,8 +41,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673487,
-        1108691413
+        1108691413,
+        85673487
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":421175231,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423087,
     "wof:name":"Beirut",
     "wof:parent_id":1108691413,
     "wof:placetype":"locality",

--- a/data/421/175/453/421175453.geojson
+++ b/data/421/175/453/421175453.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421172015
+        421172015,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175453,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423094,
     "wof:name":"Zouk Mikael",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",

--- a/data/421/175/453/421175453.geojson
+++ b/data/421/175/453/421175453.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0632\u0648\u0642 \u0645\u0643\u0627\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Zouk Mikael"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175453,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0632\u0648\u0642 \u0645\u0643\u0627\u064a\u0644",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Zouk Mikael",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/175/455/421175455.geojson
+++ b/data/421/175/455/421175455.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074351,
-        421172017
+        421172017,
+        1377074351
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175455,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423094,
     "wof:name":"Zahle",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",

--- a/data/421/175/455/421175455.geojson
+++ b/data/421/175/455/421175455.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0632\u062d\u0644\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Zahle"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175455,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0632\u062d\u0644\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Zahle",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/177/639/421177639.geojson
+++ b/data/421/177/639/421177639.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0645\u0634\u064a\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Amsheet"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421177639,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0639\u0645\u0634\u064a\u062a",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Amsheet",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/177/639/421177639.geojson
+++ b/data/421/177/639/421177639.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421194845
+        421194845,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421177639,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423086,
     "wof:name":"Amsheet",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",

--- a/data/421/178/155/421178155.geojson
+++ b/data/421/178/155/421178155.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u062f\u062b"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hadath"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421178155,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0627\u0644\u062d\u062f\u062b",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Hadath",
     "wof:parent_id":421202301,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/178/155/421178155.geojson
+++ b/data/421/178/155/421178155.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421202301
+        421202301,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421178155,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Hadath",
     "wof:parent_id":421202301,
     "wof:placetype":"locality",

--- a/data/421/178/161/421178161.geojson
+++ b/data/421/178/161/421178161.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u064a\u062c\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mrayjat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421178161,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0627\u0644\u0645\u0631\u064a\u062c\u0627\u062a",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mrayjat",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/178/161/421178161.geojson
+++ b/data/421/178/161/421178161.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.806846,33.8033995,35.806846,33.8033995",
+    "geom:bbox":"35.806846,33.803399,35.806846,33.803399",
     "geom:latitude":33.803399,
     "geom:longitude":35.806846,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074351,
-        421172017
+        421172017,
+        1377074351
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009172,
-    "wof:geomhash":"27be9556a0cb4f22a00afe7d7e63698f",
+    "wof:geomhash":"3b349fdb7aa3f8c4b5d846e1954fa7ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421178161,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mrayjat",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     35.806846,
-    33.8033995,
+    33.803399,
     35.806846,
-    33.8033995
+    33.803399
 ],
-  "geometry": {"coordinates":[35.806846,33.8033995],"type":"Point"}
+  "geometry": {"coordinates":[35.806846,33.803399],"type":"Point"}
 }

--- a/data/421/178/167/421178167.geojson
+++ b/data/421/178/167/421178167.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421178167,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423087,
     "wof:name":"As Sanawbara",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/178/167/421178167.geojson
+++ b/data/421/178/167/421178167.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0635\u0646\u0648\u0628\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "As Sanawbara"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421178167,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0627\u0644\u0635\u0646\u0648\u0628\u0631\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"As Sanawbara",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/178/543/421178543.geojson
+++ b/data/421/178/543/421178543.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421178543,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423094,
     "wof:name":"Unesco",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/178/543/421178543.geojson
+++ b/data/421/178/543/421178543.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0648\u0646\u064a\u0633\u0643\u0648"
+    ],
+    "name:eng_x_preferred":[
+        "Unesco"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421178543,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0627\u0648\u0646\u064a\u0633\u0643\u0648",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Unesco",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/181/893/421181893.geojson
+++ b/data/421/181/893/421181893.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0644\u0629 \u0627\u0644\u062e\u064a\u0627\u0637"
+    ],
+    "name:eng_x_preferred":[
+        "Tallet Al Khayat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421181893,
-    "wof:lastmodified":1566593998,
-    "wof:name":"\u062a\u0644\u0629 \u0627\u0644\u062e\u064a\u0627\u0637",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tallet Al Khayat",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/181/893/421181893.geojson
+++ b/data/421/181/893/421181893.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.487213,33.8814515,35.487213,33.8814515",
+    "geom:bbox":"35.487213,33.881451,35.487213,33.881451",
     "geom:latitude":33.881451,
     "geom:longitude":35.487213,
     "iso:country":"LB",
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -54,7 +54,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009311,
-    "wof:geomhash":"b9c532cd6d93d85120f2e318c731924b",
+    "wof:geomhash":"ab74def50a171abcd7a82e3040c08e30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421181893,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tallet Al Khayat",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
@@ -76,9 +76,9 @@
 },
   "bbox": [
     35.487213,
-    33.8814515,
+    33.881451,
     35.487213,
-    33.8814515
+    33.881451
 ],
-  "geometry": {"coordinates":[35.487213,33.8814515],"type":"Point"}
+  "geometry": {"coordinates":[35.487213,33.881451],"type":"Point"}
 }

--- a/data/421/181/895/421181895.geojson
+++ b/data/421/181/895/421181895.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0633\u062a\u0634\u0641\u0649 \u0627\u0644\u0631\u0648\u0645 \u0627\u0644\u0627\u0648\u0631\u062b\u0648\u0630\u0643\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Saint George Hospital"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421181895,
-    "wof:lastmodified":1566593998,
-    "wof:name":"\u0645\u0633\u062a\u0634\u0641\u0649 \u0627\u0644\u0631\u0648\u0645 \u0627\u0644\u0627\u0648\u0631\u062b\u0648\u0630\u0643\u0633",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Saint George Hospital",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/181/895/421181895.geojson
+++ b/data/421/181/895/421181895.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.5270515,33.8934725,35.5270515,33.8934725",
+    "geom:bbox":"35.527051,33.893473,35.527051,33.893473",
     "geom:latitude":33.893473,
     "geom:longitude":35.527051,
     "iso:country":"LB",
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -54,7 +54,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009312,
-    "wof:geomhash":"b485911d48d98121c63bedfdceede4ca",
+    "wof:geomhash":"dde1649863b8fc5b0853fd4aed6cf5cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421181895,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423092,
     "wof:name":"Saint George Hospital",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
@@ -75,10 +75,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    35.5270515,
-    33.8934725,
-    35.5270515,
-    33.8934725
+    35.527051,
+    33.893473,
+    35.527051,
+    33.893473
 ],
-  "geometry": {"coordinates":[35.5270515,33.8934725],"type":"Point"}
+  "geometry": {"coordinates":[35.527051,33.893473],"type":"Point"}
 }

--- a/data/421/183/165/421183165.geojson
+++ b/data/421/183/165/421183165.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691445
+        1108691445,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183165,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423094,
     "wof:name":"Zgharta",
     "wof:parent_id":1108691445,
     "wof:placetype":"locality",

--- a/data/421/183/165/421183165.geojson
+++ b/data/421/183/165/421183165.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0632\u063a\u0631\u062a\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Zgharta"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183165,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0632\u063a\u0631\u062a\u0627",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Zgharta",
     "wof:parent_id":1108691445,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/183/895/421183895.geojson
+++ b/data/421/183/895/421183895.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0635\u0641\u0631\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "As Safra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183895,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0627\u0644\u0635\u0641\u0631\u0627",
+    "wof:lastmodified":1601068391,
+    "wof:name":"As Safra",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/183/895/421183895.geojson
+++ b/data/421/183/895/421183895.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.63768,34.0425495,35.63768,34.0425495",
+    "geom:bbox":"35.63768,34.042549,35.63768,34.042549",
     "geom:latitude":34.042549,
     "geom:longitude":35.63768,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421172015
+        421172015,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009391,
-    "wof:geomhash":"23e228acd7a1aea5ef0d1de932d420cf",
+    "wof:geomhash":"363908037170bc0175da7d9d2f7e4d2f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183895,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423087,
     "wof:name":"As Safra",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     35.63768,
-    34.0425495,
+    34.042549,
     35.63768,
-    34.0425495
+    34.042549
 ],
-  "geometry": {"coordinates":[35.63768,34.0425495],"type":"Point"}
+  "geometry": {"coordinates":[35.63768,34.042549],"type":"Point"}
 }

--- a/data/421/183/923/421183923.geojson
+++ b/data/421/183/923/421183923.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0633\u0637\u0629 \u0627\u0644\u0641\u0648\u0642\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Basta Al Fawqa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421183923,
-    "wof:lastmodified":1566594002,
-    "wof:name":"\u0628\u0633\u0637\u0629 \u0627\u0644\u0641\u0648\u0642\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Basta Al Fawqa",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/183/923/421183923.geojson
+++ b/data/421/183/923/421183923.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421183923,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Basta Al Fawqa",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/184/181/421184181.geojson
+++ b/data/421/184/181/421184181.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421184181,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tallet Al Druze",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/184/181/421184181.geojson
+++ b/data/421/184/181/421184181.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0644\u0629 \u0627\u0644\u062f\u0631\u0648\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Tallet Al Druze"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421184181,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u062a\u0644\u0629 \u0627\u0644\u062f\u0631\u0648\u0632",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tallet Al Druze",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/184/183/421184183.geojson
+++ b/data/421/184/183/421184183.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":22724435,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85673491,
         102191569,
         85632533,
-        1108691425
+        1108691425,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184183,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Justice Palace",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/184/183/421184183.geojson
+++ b/data/421/184/183/421184183.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0642\u0635\u0631 \u0627\u0644\u0639\u062f\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Justice Palace"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184183,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u0642\u0635\u0631 \u0627\u0644\u0639\u062f\u0644",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Justice Palace",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/184/453/421184453.geojson
+++ b/data/421/184/453/421184453.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.510988,33.8785745,35.510988,33.8785745",
+    "geom:bbox":"35.510988,33.878574,35.510988,33.878574",
     "geom:latitude":33.878574,
     "geom:longitude":35.510988,
     "iso:country":"LB",
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -54,7 +54,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009411,
-    "wof:geomhash":"3af23d8834d4a6ca39291c9308f8a63e",
+    "wof:geomhash":"08623928d02cc8d2a9386be8dea6f7ef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421184453,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Al Naba'a",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
@@ -76,9 +76,9 @@
 },
   "bbox": [
     35.510988,
-    33.8785745,
+    33.878574,
     35.510988,
-    33.8785745
+    33.878574
 ],
-  "geometry": {"coordinates":[35.510988,33.8785745],"type":"Point"}
+  "geometry": {"coordinates":[35.510988,33.878574],"type":"Point"}
 }

--- a/data/421/184/453/421184453.geojson
+++ b/data/421/184/453/421184453.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u0646\u0628\u0639"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Al Naba'a"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421184453,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u0646\u0628\u0639",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Al Naba'a",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/123/421186123.geojson
+++ b/data/421/186/123/421186123.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673495,
-        1108691429
+        1108691429,
+        85673495
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186123,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Arnoun",
     "wof:parent_id":1108691429,
     "wof:placetype":"locality",

--- a/data/421/186/123/421186123.geojson
+++ b/data/421/186/123/421186123.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0631\u0646\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Arnoun"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186123,
-    "wof:lastmodified":1566593998,
-    "wof:name":"\u0627\u0631\u0646\u0648\u0646",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Arnoun",
     "wof:parent_id":1108691429,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/125/421186125.geojson
+++ b/data/421/186/125/421186125.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0639\u0628\u062f\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Baabda"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186125,
-    "wof:lastmodified":1566593998,
-    "wof:name":"\u0628\u0639\u0628\u062f\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Baabda",
     "wof:parent_id":421202301,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/125/421186125.geojson
+++ b/data/421/186/125/421186125.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.533298,33.8531335,35.533298,33.8531335",
+    "geom:bbox":"35.533298,33.853133,35.533298,33.853133",
     "geom:latitude":33.853133,
     "geom:longitude":35.533298,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421202301
+        421202301,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009471,
-    "wof:geomhash":"a0f38fde0df476093f64e84d4844a8da",
+    "wof:geomhash":"4412638663e942a99303b32eed5f86fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186125,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Baabda",
     "wof:parent_id":421202301,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     35.533298,
-    33.8531335,
+    33.853133,
     35.533298,
-    33.8531335
+    33.853133
 ],
-  "geometry": {"coordinates":[35.533298,33.8531335],"type":"Point"}
+  "geometry": {"coordinates":[35.533298,33.853133],"type":"Point"}
 }

--- a/data/421/186/183/421186183.geojson
+++ b/data/421/186/183/421186183.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0646\u062c\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Anjar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186183,
-    "wof:lastmodified":1566593998,
-    "wof:name":"\u0639\u0646\u062c\u0631",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Anjar",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/183/421186183.geojson
+++ b/data/421/186/183/421186183.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074351,
-        421172017
+        421172017,
+        1377074351
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186183,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423086,
     "wof:name":"Anjar",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",

--- a/data/421/186/187/421186187.geojson
+++ b/data/421/186/187/421186187.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0634\u0631\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Bsharri"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186187,
-    "wof:lastmodified":1566593998,
-    "wof:name":"\u0628\u0634\u0631\u064a",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bsharri",
     "wof:parent_id":1108691411,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/187/421186187.geojson
+++ b/data/421/186/187/421186187.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691411
+        1108691411,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186187,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bsharri",
     "wof:parent_id":1108691411,
     "wof:placetype":"locality",

--- a/data/421/186/191/421186191.geojson
+++ b/data/421/186/191/421186191.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062f\u064a\u0631 \u0627\u0644\u0642\u0645\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Deir Al Qamar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186191,
-    "wof:lastmodified":1566593998,
-    "wof:name":"\u062f\u064a\u0631 \u0627\u0644\u0642\u0645\u0631",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Deir Al Qamar",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/191/421186191.geojson
+++ b/data/421/186/191/421186191.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.56361,33.6987075,35.56361,33.6987075",
+    "geom:bbox":"35.56361,33.698707,35.56361,33.698707",
     "geom:latitude":33.698707,
     "geom:longitude":35.56361,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691419
+        1108691419,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009473,
-    "wof:geomhash":"7e2c4296eb6a1f2a38ec3b9635ff448f",
+    "wof:geomhash":"9817680a920fb5a48a6c3f0932dbeb95",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186191,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423088,
     "wof:name":"Deir Al Qamar",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     35.56361,
-    33.6987075,
+    33.698707,
     35.56361,
-    33.6987075
+    33.698707
 ],
-  "geometry": {"coordinates":[35.56361,33.6987075],"type":"Point"}
+  "geometry": {"coordinates":[35.56361,33.698707],"type":"Point"}
 }

--- a/data/421/186/193/421186193.geojson
+++ b/data/421/186/193/421186193.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421172015
+        421172015,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186193,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Harissa",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",

--- a/data/421/186/193/421186193.geojson
+++ b/data/421/186/193/421186193.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u0631\u064a\u0635\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Harissa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186193,
-    "wof:lastmodified":1566593997,
-    "wof:name":"\u062d\u0631\u064a\u0635\u0627",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Harissa",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/195/421186195.geojson
+++ b/data/421/186/195/421186195.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421172015
+        421172015,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186195,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ghadir",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",

--- a/data/421/186/195/421186195.geojson
+++ b/data/421/186/195/421186195.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u063a\u062f\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Ghadir"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186195,
-    "wof:lastmodified":1566593997,
-    "wof:name":"\u063a\u062f\u064a\u0631",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ghadir",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/397/421186397.geojson
+++ b/data/421/186/397/421186397.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0647\u0631\u0645\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Hermel"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009479,
-    "wof:geomhash":"dd1e190c74b220e6820737f842b4818c",
+    "wof:geomhash":"893aa54d598eb36a84743575b2737bd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421186397,
-    "wof:lastmodified":1474311211,
-    "wof:name":"\u0647\u0631\u0645\u0644",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Hermel",
     "wof:parent_id":85673479,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/186/397/421186397.geojson
+++ b/data/421/186/397/421186397.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421186397,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hermel",
     "wof:parent_id":85673479,
     "wof:placetype":"county",

--- a/data/421/187/911/421187911.geojson
+++ b/data/421/187/911/421187911.geojson
@@ -67,7 +67,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Baalbek Hermel",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/421/187/911/421187911.geojson
+++ b/data/421/187/911/421187911.geojson
@@ -16,6 +16,12 @@
     "mz:max_zoom":11.0,
     "mz:min_zoom":8.7,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0639\u0644\u0628\u0643 \u0627\u0644\u0647\u0631\u0645\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Baalbek Hermel"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1529541196,
-    "wof:name":"\u0628\u0639\u0644\u0628\u0643 \u0627\u0644\u0647\u0631\u0645\u0644",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Baalbek Hermel",
     "wof:parent_id":85632533,
     "wof:placetype":"region",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/187/915/421187915.geojson
+++ b/data/421/187/915/421187915.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0648\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Al Chouf"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009528,
-    "wof:geomhash":"6117c833bb4eae000d40ad4ffe1f7aab",
+    "wof:geomhash":"8cc3cc73faf92b01a6823955e08081dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421187915,
-    "wof:lastmodified":1474311210,
-    "wof:name":"\u0627\u0644\u0634\u0648\u0641",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Chouf",
     "wof:parent_id":85673491,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/187/915/421187915.geojson
+++ b/data/421/187/915/421187915.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421187915,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Chouf",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/187/917/421187917.geojson
+++ b/data/421/187/917/421187917.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421187917,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bsharre",
     "wof:parent_id":85673483,
     "wof:placetype":"county",

--- a/data/421/187/917/421187917.geojson
+++ b/data/421/187/917/421187917.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0634\u0631\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Bsharre"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009528,
-    "wof:geomhash":"d0f4fef4d46646c8fe384f44f692744d",
+    "wof:geomhash":"02cc9aaf9eaee27750ee0d304c39f671",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421187917,
-    "wof:lastmodified":1474311210,
-    "wof:name":"\u0628\u0634\u0631\u064a",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bsharre",
     "wof:parent_id":85673483,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/188/349/421188349.geojson
+++ b/data/421/188/349/421188349.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0627\u0644\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Aliah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009542,
-    "wof:geomhash":"fa6b9464cb3cf3a09f739078b017afea",
+    "wof:geomhash":"0af9804f6e7410885d86949b3813b7e4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421188349,
-    "wof:lastmodified":1474311210,
-    "wof:name":"\u0639\u0627\u0644\u064a\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Aliah",
     "wof:parent_id":85673491,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/188/349/421188349.geojson
+++ b/data/421/188/349/421188349.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421188349,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423086,
     "wof:name":"Aliah",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/188/559/421188559.geojson
+++ b/data/421/188/559/421188559.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u062a\u064a\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ain At Tina"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421188559,
-    "wof:lastmodified":1566593997,
-    "wof:name":"\u0639\u064a\u0646 \u0627\u0644\u062a\u064a\u0646\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Ain At Tina",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/188/559/421188559.geojson
+++ b/data/421/188/559/421188559.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421188559,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ain At Tina",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/567/421188567.geojson
+++ b/data/421/188/567/421188567.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421188567,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Mar Nicolas",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/567/421188567.geojson
+++ b/data/421/188/567/421188567.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0627\u0631 \u0646\u0642\u0648\u0644\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Mar Nicolas"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421188567,
-    "wof:lastmodified":1566593997,
-    "wof:name":"\u0645\u0627\u0631 \u0646\u0642\u0648\u0644\u0627",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Mar Nicolas",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/555/421190555.geojson
+++ b/data/421/190/555/421190555.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0627\u0631\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Ariz"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190555,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0627\u0644\u0627\u0631\u0632",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Ariz",
     "wof:parent_id":1108691411,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/555/421190555.geojson
+++ b/data/421/190/555/421190555.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691411
+        1108691411,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190555,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Ariz",
     "wof:parent_id":1108691411,
     "wof:placetype":"locality",

--- a/data/421/190/561/421190561.geojson
+++ b/data/421/190/561/421190561.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691425
+        1108691425,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190561,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423088,
     "wof:name":"Dbayeh",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",

--- a/data/421/190/561/421190561.geojson
+++ b/data/421/190/561/421190561.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0636\u0628\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Dbayeh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190561,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0636\u0628\u064a\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Dbayeh",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/565/421190565.geojson
+++ b/data/421/190/565/421190565.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0627\u0634\u0631\u0641\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Achrafieh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421190565,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u0627\u0644\u0627\u0634\u0631\u0641\u064a\u0629",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Achrafieh",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/565/421190565.geojson
+++ b/data/421/190/565/421190565.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421190565,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Achrafieh",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/190/567/421190567.geojson
+++ b/data/421/190/567/421190567.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421190567,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Hazmiyeh",
     "wof:parent_id":85673487,
     "wof:placetype":"locality",

--- a/data/421/190/567/421190567.geojson
+++ b/data/421/190/567/421190567.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u0627\u0632\u0645\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hazmiyeh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421190567,
-    "wof:lastmodified":1551727702,
-    "wof:name":"\u0627\u0644\u062d\u0627\u0632\u0645\u064a\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Hazmiyeh",
     "wof:parent_id":85673487,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/569/421190569.geojson
+++ b/data/421/190/569/421190569.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u064a\u0646\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mina"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421190569,
-    "wof:lastmodified":1551727703,
-    "wof:name":"\u0627\u0644\u0645\u064a\u0646\u0627\u0621",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Mina",
     "wof:parent_id":1108691443,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/569/421190569.geojson
+++ b/data/421/190/569/421190569.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.8248705,34.439123,35.8248705,34.439123",
+    "geom:bbox":"35.824871,34.439123,35.824871,34.439123",
     "geom:latitude":34.439123,
     "geom:longitude":35.824871,
     "iso:country":"LB",
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691443
+        1108691443,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -52,7 +52,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009662,
-    "wof:geomhash":"d34d094fbfa0d1b9a064bea5eaf5655e",
+    "wof:geomhash":"813040e19f1eb1f3d29a6e3b2d44fc20",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421190569,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mina",
     "wof:parent_id":1108691443,
     "wof:placetype":"locality",
@@ -75,10 +75,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    35.8248705,
+    35.824871,
     34.439123,
-    35.8248705,
+    35.824871,
     34.439123
 ],
-  "geometry": {"coordinates":[35.8248705,34.439123],"type":"Point"}
+  "geometry": {"coordinates":[35.824871,34.439123],"type":"Point"}
 }

--- a/data/421/190/571/421190571.geojson
+++ b/data/421/190/571/421190571.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691419
+        1108691419,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190571,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Barouk",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",

--- a/data/421/190/571/421190571.geojson
+++ b/data/421/190/571/421190571.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0627\u0631\u0648\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Barouk"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190571,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u0627\u0644\u0628\u0627\u0631\u0648\u0643",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Barouk",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/573/421190573.geojson
+++ b/data/421/190/573/421190573.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u062f\u064a\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Jdeideh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190573,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u062c\u062f\u064a\u062f\u0629",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jdeideh",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/573/421190573.geojson
+++ b/data/421/190/573/421190573.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691425
+        1108691425,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190573,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jdeideh",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",

--- a/data/421/190/575/421190575.geojson
+++ b/data/421/190/575/421190575.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.6681435,34.249814,35.6681435,34.249814",
+    "geom:bbox":"35.668143,34.249814,35.668143,34.249814",
     "geom:latitude":34.249814,
     "geom:longitude":35.668143,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        421204111
+        421204111,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009662,
-    "wof:geomhash":"6a04e6f41c7876f06590e0e2d951f6aa",
+    "wof:geomhash":"a74f08ecf9ca8c6f3af8a555b9765f98",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190575,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Batroun",
     "wof:parent_id":421204111,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    35.6681435,
+    35.668143,
     34.249814,
-    35.6681435,
+    35.668143,
     34.249814
 ],
-  "geometry": {"coordinates":[35.6681435,34.249814],"type":"Point"}
+  "geometry": {"coordinates":[35.668143,34.249814],"type":"Point"}
 }

--- a/data/421/190/575/421190575.geojson
+++ b/data/421/190/575/421190575.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u062a\u0631\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Batroun"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190575,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0627\u0644\u0628\u062a\u0631\u0648\u0646",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Batroun",
     "wof:parent_id":421204111,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/581/421190581.geojson
+++ b/data/421/190/581/421190581.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0628\u0637\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Nabatieh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190581,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0627\u0644\u0646\u0628\u0637\u064a\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Nabatieh",
     "wof:parent_id":1108691429,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/581/421190581.geojson
+++ b/data/421/190/581/421190581.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673495,
-        1108691429
+        1108691429,
+        85673495
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190581,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423091,
     "wof:name":"Nabatieh",
     "wof:parent_id":1108691429,
     "wof:placetype":"locality",

--- a/data/421/190/585/421190585.geojson
+++ b/data/421/190/585/421190585.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u064a\u062a \u0645\u0631\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Beit Meir"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190585,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u0628\u064a\u062a \u0645\u0631\u064a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Beit Meir",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/585/421190585.geojson
+++ b/data/421/190/585/421190585.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691425
+        1108691425,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190585,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423087,
     "wof:name":"Beit Meir",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",

--- a/data/421/190/587/421190587.geojson
+++ b/data/421/190/587/421190587.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691425
+        1108691425,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190587,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423087,
     "wof:name":"Beit Al Koko",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",

--- a/data/421/190/587/421190587.geojson
+++ b/data/421/190/587/421190587.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u064a\u062a \u0627\u0644\u0643\u0648\u0643\u0648"
+    ],
+    "name:eng_x_preferred":[
+        "Beit Al Koko"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190587,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0628\u064a\u062a \u0627\u0644\u0643\u0648\u0643\u0648",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Beit Al Koko",
     "wof:parent_id":1108691425,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/589/421190589.geojson
+++ b/data/421/190/589/421190589.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0631\u064a\u0633\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Braissat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190589,
-    "wof:lastmodified":1566593999,
-    "wof:name":"\u0628\u0631\u064a\u0633\u0627\u062a",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Braissat",
     "wof:parent_id":1108691411,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/589/421190589.geojson
+++ b/data/421/190/589/421190589.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691411
+        1108691411,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190589,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Braissat",
     "wof:parent_id":1108691411,
     "wof:placetype":"locality",

--- a/data/421/190/591/421190591.geojson
+++ b/data/421/190/591/421190591.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673499,
-        890451987
+        890451987,
+        85673499
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190591,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bramiye Et Tahta",
     "wof:parent_id":890451987,
     "wof:placetype":"locality",

--- a/data/421/190/591/421190591.geojson
+++ b/data/421/190/591/421190591.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0631\u0627\u0645\u064a\u0629 \u0627\u0644\u062a\u062d\u062a\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Bramiye Et Tahta"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190591,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u0628\u0631\u0627\u0645\u064a\u0629 \u0627\u0644\u062a\u062d\u062a\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bramiye Et Tahta",
     "wof:parent_id":890451987,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/190/601/421190601.geojson
+++ b/data/421/190/601/421190601.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.632511,33.9735445,35.632511,33.9735445",
+    "geom:bbox":"35.632511,33.973545,35.632511,33.973545",
     "geom:latitude":33.973545,
     "geom:longitude":35.632511,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421172015
+        421172015,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459009663,
-    "wof:geomhash":"18eeab07941da349ec786b7fcef5be02",
+    "wof:geomhash":"3c1d2044752ea945d7b0eb4c40f7c78e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190601,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jounieh",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     35.632511,
-    33.9735445,
+    33.973545,
     35.632511,
-    33.9735445
+    33.973545
 ],
-  "geometry": {"coordinates":[35.632511,33.9735445],"type":"Point"}
+  "geometry": {"coordinates":[35.632511,33.973545],"type":"Point"}
 }

--- a/data/421/190/601/421190601.geojson
+++ b/data/421/190/601/421190601.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0648\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Jounieh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190601,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u062c\u0648\u0646\u064a\u0629",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jounieh",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/193/045/421193045.geojson
+++ b/data/421/193/045/421193045.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691423
+        1108691423,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421193045,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Anfeh",
     "wof:parent_id":1108691423,
     "wof:placetype":"locality",

--- a/data/421/193/045/421193045.geojson
+++ b/data/421/193/045/421193045.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0646\u0641\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Anfeh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421193045,
-    "wof:lastmodified":1566593996,
-    "wof:name":"\u0627\u0646\u0641\u0647",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Anfeh",
     "wof:parent_id":1108691423,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/193/625/421193625.geojson
+++ b/data/421/193/625/421193625.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0631\u0645\u0627\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ain El Remmaneh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421193625,
-    "wof:lastmodified":1566593996,
-    "wof:name":"\u0639\u064a\u0646 \u0627\u0644\u0631\u0645\u0627\u0646\u0629",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ain El Remmaneh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/193/625/421193625.geojson
+++ b/data/421/193/625/421193625.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":22724428,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85673491,
         102191569,
         85632533,
-        421202301
+        421202301,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421193625,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ain El Remmaneh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/194/367/421194367.geojson
+++ b/data/421/194/367/421194367.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0642\u0631\u064a\u0637\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Kraytem"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421194367,
-    "wof:lastmodified":1566593995,
-    "wof:name":"\u0642\u0631\u064a\u0637\u0645",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kraytem",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/194/367/421194367.geojson
+++ b/data/421/194/367/421194367.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421194367,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kraytem",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/194/611/421194611.geojson
+++ b/data/421/194/611/421194611.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0627\u0644\u064a\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Aley"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194611,
-    "wof:lastmodified":1566593995,
-    "wof:name":"\u0639\u0627\u0644\u064a\u0647",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Aley",
     "wof:parent_id":1108691409,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/194/611/421194611.geojson
+++ b/data/421/194/611/421194611.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691409
+        1108691409,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194611,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423086,
     "wof:name":"Aley",
     "wof:parent_id":1108691409,
     "wof:placetype":"locality",

--- a/data/421/194/693/421194693.geojson
+++ b/data/421/194/693/421194693.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u062f\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Edde"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194693,
-    "wof:lastmodified":1566593995,
-    "wof:name":"\u0627\u062f\u0647",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Edde",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/194/693/421194693.geojson
+++ b/data/421/194/693/421194693.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421194845
+        421194845,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194693,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423088,
     "wof:name":"Edde",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",

--- a/data/421/194/863/421194863.geojson
+++ b/data/421/194/863/421194863.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0644\u062d\u0635"
+    ],
+    "name:eng_x_preferred":[
+        "Balhoss"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194863,
-    "wof:lastmodified":1566593996,
-    "wof:name":"\u0628\u0644\u062d\u0635",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Balhoss",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/194/863/421194863.geojson
+++ b/data/421/194/863/421194863.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421194845
+        421194845,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194863,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Balhoss",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",

--- a/data/421/194/865/421194865.geojson
+++ b/data/421/194/865/421194865.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0634\u062a\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Chtoura"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194865,
-    "wof:lastmodified":1566593995,
-    "wof:name":"\u0634\u062a\u0648\u0631\u0629",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Chtoura",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/194/865/421194865.geojson
+++ b/data/421/194/865/421194865.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074351,
-        421172017
+        421172017,
+        1377074351
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194865,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423088,
     "wof:name":"Chtoura",
     "wof:parent_id":421172017,
     "wof:placetype":"locality",

--- a/data/421/197/143/421197143.geojson
+++ b/data/421/197/143/421197143.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421172015
+        421172015,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421197143,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sarba",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",

--- a/data/421/197/143/421197143.geojson
+++ b/data/421/197/143/421197143.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u0631\u0628\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Sarba"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421197143,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u0635\u0631\u0628\u0627",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sarba",
     "wof:parent_id":421172015,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/199/687/421199687.geojson
+++ b/data/421/199/687/421199687.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        1108691419
+        1108691419,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421199687,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Maaser El Chouf",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",

--- a/data/421/199/687/421199687.geojson
+++ b/data/421/199/687/421199687.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0639\u0627\u0635\u0631 \u0627\u0644\u0634\u0648\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Maaser El Chouf"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421199687,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u0645\u0639\u0627\u0635\u0631 \u0627\u0644\u0634\u0648\u0641",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Maaser El Chouf",
     "wof:parent_id":1108691419,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/200/109/421200109.geojson
+++ b/data/421/200/109/421200109.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691443
+        1108691443,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200109,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Qalamoun",
     "wof:parent_id":1108691443,
     "wof:placetype":"locality",

--- a/data/421/200/109/421200109.geojson
+++ b/data/421/200/109/421200109.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0642\u0644\u0645\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Al Qalamoun"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200109,
-    "wof:lastmodified":1566594000,
-    "wof:name":"\u0627\u0644\u0642\u0644\u0645\u0648\u0646",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Qalamoun",
     "wof:parent_id":1108691443,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/201/871/421201871.geojson
+++ b/data/421/201/871/421201871.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673499,
-        890451987
+        890451987,
+        85673499
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201871,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sayda",
     "wof:parent_id":890451987,
     "wof:placetype":"locality",

--- a/data/421/201/871/421201871.geojson
+++ b/data/421/201/871/421201871.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u064a\u062f\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Sayda"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201871,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u0635\u064a\u062f\u0627",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Sayda",
     "wof:parent_id":890451987,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/201/873/421201873.geojson
+++ b/data/421/201/873/421201873.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673499,
-        1108691441
+        1108691441,
+        85673499
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201873,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423094,
     "wof:name":"Tyre",
     "wof:parent_id":1108691441,
     "wof:placetype":"locality",

--- a/data/421/201/873/421201873.geojson
+++ b/data/421/201/873/421201873.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Tyre"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201873,
-    "wof:lastmodified":1566594001,
-    "wof:name":"\u0635\u0648\u0631",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Tyre",
     "wof:parent_id":1108691441,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/201/875/421201875.geojson
+++ b/data/421/201/875/421201875.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0637\u0631\u0627\u0628\u0644\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Tripoli"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -56,8 +62,8 @@
         }
     ],
     "wof:id":421201875,
-    "wof:lastmodified":1551727629,
-    "wof:name":"\u0637\u0631\u0627\u0628\u0644\u0633",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Tripoli",
     "wof:parent_id":1108691443,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/201/875/421201875.geojson
+++ b/data/421/201/875/421201875.geojson
@@ -41,8 +41,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        1377074355,
-        1108691443
+        1108691443,
+        1377074355
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":421201875,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423094,
     "wof:name":"Tripoli",
     "wof:parent_id":1108691443,
     "wof:placetype":"locality",

--- a/data/421/202/237/421202237.geojson
+++ b/data/421/202/237/421202237.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673491,
-        421194845
+        421194845,
+        85673491
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202237,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jbeil",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",

--- a/data/421/202/237/421202237.geojson
+++ b/data/421/202/237/421202237.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0628\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Jbeil"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202237,
-    "wof:lastmodified":1566593996,
-    "wof:name":"\u062c\u0628\u064a\u0644",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jbeil",
     "wof:parent_id":421194845,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/202/263/421202263.geojson
+++ b/data/421/202/263/421202263.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0633\u0637\u0627 \u0627\u0644\u062a\u062d\u062a\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Basta Et Tahta"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":421202263,
-    "wof:lastmodified":1566593997,
-    "wof:name":"\u0628\u0633\u0637\u0627 \u0627\u0644\u062a\u062d\u062a\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Basta Et Tahta",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-lb",

--- a/data/421/202/263/421202263.geojson
+++ b/data/421/202/263/421202263.geojson
@@ -43,8 +43,8 @@
     "src:geom":"quattroshapes",
     "wof:belongsto":[
         102191569,
-        890442383,
         85632533,
+        890442383,
         85673487
     ],
     "wof:breaches":[],
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":421202263,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Basta Et Tahta",
     "wof:parent_id":890442383,
     "wof:placetype":"neighbourhood",

--- a/data/421/202/377/421202377.geojson
+++ b/data/421/202/377/421202377.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.3717925,33.567144,35.3717925,33.567144",
+    "geom:bbox":"35.371792,33.567144,35.371792,33.567144",
     "geom:latitude":33.567144,
     "geom:longitude":35.371792,
     "iso:country":"LB",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632533,
-        85673499,
-        890451987
+        890451987,
+        85673499
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"LB",
     "wof:created":1459010116,
-    "wof:geomhash":"595f81ff6c8e2d6b03e3a45bfe72bece",
+    "wof:geomhash":"75d518c5a892db5a54d0abc526c8f134",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202377,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sayda Al Wastani",
     "wof:parent_id":890451987,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    35.3717925,
+    35.371792,
     33.567144,
-    35.3717925,
+    35.371792,
     33.567144
 ],
-  "geometry": {"coordinates":[35.3717925,33.567144],"type":"Point"}
+  "geometry": {"coordinates":[35.371792,33.567144],"type":"Point"}
 }

--- a/data/421/202/377/421202377.geojson
+++ b/data/421/202/377/421202377.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u064a\u062f\u0627 \u0627\u0644\u0648\u0633\u0637\u0627\u0646\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Sayda Al Wastani"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202377,
-    "wof:lastmodified":1566593996,
-    "wof:name":"\u0635\u064a\u062f\u0627 \u0627\u0644\u0648\u0633\u0637\u0627\u0646\u064a",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Sayda Al Wastani",
     "wof:parent_id":890451987,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lb",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.