### PR TITLE
Update properties of megacities

### DIFF
--- a/data/890/442/383/890442383.geojson
+++ b/data/890/442/383/890442383.geojson
@@ -655,6 +655,7 @@
     ],
     "wof:concordances":{
         "gn:id":276781,
+        "ne:id":1159150957,
         "qs_pg:id":547002,
         "wd:id":"Q3820",
         "wk:page":"Beirut"
@@ -677,7 +678,8 @@
         }
     ],
     "wof:id":890442383,
-    "wof:lastmodified":1607390901,
+    "wof:lastmodified":1608688178,
+    "wof:megacity":1,
     "wof:name":"Beirut",
     "wof:parent_id":85673487,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary