### PR TITLE
lb concordances, placetype local, and more

### DIFF
--- a/data/110/869/140/7/1108691407.geojson
+++ b/data/110/869/140/7/1108691407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076818,
-    "geom:area_square_m":782352467.33659,
+    "geom:area_square_m":782352467.336659,
     "geom:bbox":"35.955362,34.413176,36.46269,34.69208",
     "geom:latitude":34.548553,
     "geom:longitude":36.182736,
@@ -138,12 +138,13 @@
         "hasc:id":"LB.AA.AK",
         "wd:id":"Q419697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         1377074357
     ],
     "wof:country":"LB",
     "wof:created":1474310271,
-    "wof:geomhash":"8fdf963bc81677b87749893aef7a5e95",
+    "wof:geomhash":"aefd44e74a0100972355c54b845123b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108691407,
-    "wof:lastmodified":1690938514,
+    "wof:lastmodified":1695886415,
     "wof:name":"Akkar",
     "wof:parent_id":1377074357,
     "wof:placetype":"county",

--- a/data/110/869/140/9/1108691409.geojson
+++ b/data/110/869/140/9/1108691409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025766,
-    "geom:area_square_m":264841068.876557,
+    "geom:area_square_m":264841122.286282,
     "geom:bbox":"35.459272,33.705671,35.812583,33.829217",
     "geom:latitude":33.771047,
     "geom:longitude":35.611458,
@@ -138,9 +138,10 @@
         "hasc:id":"LB.JL.AL",
         "wd:id":"Q246077"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310273,
-    "wof:geomhash":"866568f372adc2ffb84e21a4e7c0c774",
+    "wof:geomhash":"0cf16d76481b40015bdd785f7e6e7071",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108691409,
-    "wof:lastmodified":1690938514,
+    "wof:lastmodified":1695886706,
     "wof:name":"Aley",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/110/869/141/1/1108691411.geojson
+++ b/data/110/869/141/1/1108691411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016262,
-    "geom:area_square_m":166220955.535744,
+    "geom:area_square_m":166221251.814045,
     "geom:bbox":"35.819276,34.180854,36.140401,34.309456",
     "geom:latitude":34.248402,
     "geom:longitude":35.985315,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"LB.NL.BC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310275,
-    "wof:geomhash":"d75ef8c4b4730281907246e66757e687",
+    "wof:geomhash":"b838f96bb786bf98779c5613df8e757c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108691411,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Bcharre",
     "wof:parent_id":1377074355,
     "wof:placetype":"county",

--- a/data/110/869/141/7/1108691417.geojson
+++ b/data/110/869/141/7/1108691417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02649,
-    "geom:area_square_m":274242039.487861,
+    "geom:area_square_m":274242126.946013,
     "geom:bbox":"35.297715,33.055026,35.506799,33.312788",
     "geom:latitude":33.150796,
     "geom:longitude":35.401282,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LB.NA.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310278,
-    "wof:geomhash":"4461068ec24f7fc9e4c819ed48267a03",
+    "wof:geomhash":"6c5564071c7a6f395324c44fec2ea499",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108691417,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"Bent Jbeil",
     "wof:parent_id":85673495,
     "wof:placetype":"county",

--- a/data/110/869/141/9/1108691419.geojson
+++ b/data/110/869/141/9/1108691419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046808,
-    "geom:area_square_m":481787145.807809,
+    "geom:area_square_m":481787440.840914,
     "geom:bbox":"35.384681,33.489365,35.764041,33.763805",
     "geom:latitude":33.652999,
     "geom:longitude":35.563814,
@@ -150,9 +150,10 @@
         "hasc:id":"LB.JL.CH",
         "wd:id":"Q246999"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310279,
-    "wof:geomhash":"3c87cddac91a500cfbd49b35968aa095",
+    "wof:geomhash":"48918f0dd2d8ab1c7e2bc6f077af7328",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1108691419,
-    "wof:lastmodified":1690938514,
+    "wof:lastmodified":1695886706,
     "wof:name":"Chouf",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/110/869/142/1/1108691421.geojson
+++ b/data/110/869/142/1/1108691421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051743,
-    "geom:area_square_m":528013677.855358,
+    "geom:area_square_m":528013707.521794,
     "geom:bbox":"36.137252,34.259171,36.495199,34.521094",
     "geom:latitude":34.385021,
     "geom:longitude":36.306151,
@@ -129,9 +129,10 @@
         "hasc:id":"LB.BH.HE",
         "wd:id":"Q2347572"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310281,
-    "wof:geomhash":"77f60a4c4e7286ad5616ee3d8321c721",
+    "wof:geomhash":"891fa767f9c97baa439e0389c7872479",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108691421,
-    "wof:lastmodified":1690938512,
+    "wof:lastmodified":1695886706,
     "wof:name":"El Hermel",
     "wof:parent_id":1377074353,
     "wof:placetype":"county",

--- a/data/110/869/142/3/1108691423.geojson
+++ b/data/110/869/142/3/1108691423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016653,
-    "geom:area_square_m":170059951.319096,
+    "geom:area_square_m":170059874.898369,
     "geom:bbox":"35.707823,34.244782,35.870242,34.419529",
     "geom:latitude":34.324675,
     "geom:longitude":35.798684,
@@ -132,9 +132,10 @@
         "hasc:id":"LB.NL.KO",
         "wd:id":"Q2414816"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310282,
-    "wof:geomhash":"fb704078292030c8eb373279bcd5fc53",
+    "wof:geomhash":"198ad115873373641deb2eae1c14d1d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108691423,
-    "wof:lastmodified":1690938513,
+    "wof:lastmodified":1695886706,
     "wof:name":"El Koura",
     "wof:parent_id":1377074355,
     "wof:placetype":"county",

--- a/data/110/869/142/5/1108691425.geojson
+++ b/data/110/869/142/5/1108691425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025541,
-    "geom:area_square_m":262093186.665546,
+    "geom:area_square_m":262093403.458945,
     "geom:bbox":"35.528118,33.839597,35.903654,33.986356",
     "geom:latitude":33.912912,
     "geom:longitude":35.710156,
@@ -160,9 +160,10 @@
         "hasc:id":"LB.JL.MT",
         "wd:id":"Q246074"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310284,
-    "wof:geomhash":"4cbfad6daff5db348f5d7122de8632e0",
+    "wof:geomhash":"9d0c9bbec27cfd344182923fc3bd3280",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":1108691425,
-    "wof:lastmodified":1690938513,
+    "wof:lastmodified":1695886706,
     "wof:name":"El Meten",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/110/869/142/7/1108691427.geojson
+++ b/data/110/869/142/7/1108691427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035894,
-    "geom:area_square_m":366301348.396631,
+    "geom:area_square_m":366301460.281723,
     "geom:bbox":"35.854078,34.274239,36.182529,34.513638",
     "geom:latitude":34.381042,
     "geom:longitude":36.04035,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"LB.NL.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310285,
-    "wof:geomhash":"05aba899f33aa3e2dc8e7e4b6fc50a0d",
+    "wof:geomhash":"d5d99d90edbd3cb84088f412c46eedc7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108691427,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886786,
     "wof:name":"El Minieh-Dennie",
     "wof:parent_id":1377074355,
     "wof:placetype":"county",

--- a/data/110/869/142/9/1108691429.geojson
+++ b/data/110/869/142/9/1108691429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029753,
-    "geom:area_square_m":307168702.115307,
+    "geom:area_square_m":307168693.871318,
     "geom:bbox":"35.313549,33.293332,35.550359,33.512688",
     "geom:latitude":33.391598,
     "geom:longitude":35.452169,
@@ -127,9 +127,10 @@
         "hasc:id":"LB.NA.NA",
         "wd:id":"Q680602"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310287,
-    "wof:geomhash":"165cf467723e30a02b7b9564b8a71b51",
+    "wof:geomhash":"b15c3738adf35a612163f12251f22e34",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108691429,
-    "wof:lastmodified":1690938512,
+    "wof:lastmodified":1695886706,
     "wof:name":"El Nabatieh",
     "wof:parent_id":85673495,
     "wof:placetype":"county",

--- a/data/110/869/143/1/1108691431.geojson
+++ b/data/110/869/143/1/1108691431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021842,
-    "geom:area_square_m":225532961.97166,
+    "geom:area_square_m":225532961.971627,
     "geom:bbox":"35.6052855507,33.2712927582,35.7945084623,33.4817931498",
     "geom:latitude":33.377899,
     "geom:longitude":35.697668,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"LB.NA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310288,
-    "wof:geomhash":"4a9b78e7825ca0524c4bd898abf45deb",
+    "wof:geomhash":"0375f943338b7fcc3350e0f6889aa3b6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108691431,
-    "wof:lastmodified":1566593945,
+    "wof:lastmodified":1695886706,
     "wof:name":"Hasbaya",
     "wof:parent_id":85673495,
     "wof:placetype":"county",

--- a/data/110/869/143/5/1108691435.geojson
+++ b/data/110/869/143/5/1108691435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022609,
-    "geom:area_square_m":233136314.478272,
+    "geom:area_square_m":233136157.997422,
     "geom:bbox":"35.419216,33.357445,35.633794,33.59634",
     "geom:latitude":33.49448,
     "geom:longitude":35.548451,
@@ -129,9 +129,10 @@
         "hasc:id":"LB.JA.JE",
         "wd:id":"Q2210780"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310290,
-    "wof:geomhash":"43a2fa38ab9a28b993ae7e5bef2ffac8",
+    "wof:geomhash":"fa1b70e332184e8230a095a3343976a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108691435,
-    "wof:lastmodified":1690938513,
+    "wof:lastmodified":1695886706,
     "wof:name":"Jezzine",
     "wof:parent_id":85673499,
     "wof:placetype":"county",

--- a/data/110/869/143/7/1108691437.geojson
+++ b/data/110/869/143/7/1108691437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025328,
-    "geom:area_square_m":261857445.629981,
+    "geom:area_square_m":261857437.424083,
     "geom:bbox":"35.425359,33.116192,35.640199,33.398395",
     "geom:latitude":33.267594,
     "geom:longitude":35.533427,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"LB.NA.MJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310291,
-    "wof:geomhash":"5884544b51a8e1adcd6cb8889d1d91c2",
+    "wof:geomhash":"45f7dfd66cc00fa833269ce63f2b6a00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108691437,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886787,
     "wof:name":"Marjaayoun",
     "wof:parent_id":85673495,
     "wof:placetype":"county",

--- a/data/110/869/143/9/1108691439.geojson
+++ b/data/110/869/143/9/1108691439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051778,
-    "geom:area_square_m":533737165.452973,
+    "geom:area_square_m":533737450.327156,
     "geom:bbox":"35.683235,33.339199,36.05307,33.688773",
     "geom:latitude":33.524906,
     "geom:longitude":35.865363,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"LB.BQ.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310293,
-    "wof:geomhash":"aa2bedfb10426335165c4600ac90f5ad",
+    "wof:geomhash":"4f76fe509f2e007307db38f91ca6baf3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108691439,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886787,
     "wof:name":"Rachaya",
     "wof:parent_id":1377074351,
     "wof:placetype":"county",

--- a/data/110/869/144/1/1108691441.geojson
+++ b/data/110/869/144/1/1108691441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039493,
-    "geom:area_square_m":408562668.586716,
+    "geom:area_square_m":408562529.931804,
     "geom:bbox":"35.103668,33.085197,35.43226,33.338436",
     "geom:latitude":33.213357,
     "geom:longitude":35.273975,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"LB.JA.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310294,
-    "wof:geomhash":"122c619104cba45cb4aeabfeabb43dea",
+    "wof:geomhash":"f9294f2c1029aca5538cd95e052b3369",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108691441,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886787,
     "wof:name":"Sour",
     "wof:parent_id":85673499,
     "wof:placetype":"county",

--- a/data/110/869/144/3/1108691443.geojson
+++ b/data/110/869/144/3/1108691443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002717,
-    "geom:area_square_m":27717795.417502,
+    "geom:area_square_m":27717753.131281,
     "geom:bbox":"35.769316,34.373427,35.870987,34.458668",
     "geom:latitude":34.421611,
     "geom:longitude":35.834056,
@@ -147,9 +147,10 @@
         "hasc:id":"LB.NL.TR",
         "wd:id":"Q2484819"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310296,
-    "wof:geomhash":"f0fa4070b3450e54d5d9d8110975e37c",
+    "wof:geomhash":"c1c60d48cb7d4def5c762110273b25bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108691443,
-    "wof:lastmodified":1690938513,
+    "wof:lastmodified":1695886659,
     "wof:name":"Tripoli",
     "wof:parent_id":1377074355,
     "wof:placetype":"county",

--- a/data/110/869/144/5/1108691445.geojson
+++ b/data/110/869/144/5/1108691445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017231,
-    "geom:area_square_m":175892730.181827,
+    "geom:area_square_m":175892663.38711,
     "geom:bbox":"35.852405,34.26579,36.030623,34.453832",
     "geom:latitude":34.35563,
     "geom:longitude":35.920379,
@@ -129,9 +129,10 @@
         "hasc:id":"LB.NL.ZG",
         "wd:id":"Q197116"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1474310297,
-    "wof:geomhash":"df9039eb592319f264a456828a9ee6ad",
+    "wof:geomhash":"8e036ce838c79bde7f2d8b28f8297193",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108691445,
-    "wof:lastmodified":1690938514,
+    "wof:lastmodified":1695886706,
     "wof:name":"Zgharta",
     "wof:parent_id":1377074355,
     "wof:placetype":"county",

--- a/data/137/707/435/1/1377074351.geojson
+++ b/data/137/707/435/1/1377074351.geojson
@@ -81,8 +81,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"LB.BQ",
+        "iso:code":"LB-BI",
         "iso:id":"LB-BI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LB",
     "wof:geomhash":"fa7df2dc7f023dc965f81dcbd15d0c6f",
     "wof:hierarchy":[
@@ -99,7 +101,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493256,
+    "wof:lastmodified":1695884802,
     "wof:name":"Beqaa",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/137/707/435/3/1377074353.geojson
+++ b/data/137/707/435/3/1377074353.geojson
@@ -58,8 +58,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"LB.BH",
+        "iso:code":"LB-BH",
         "iso:id":"LB-BH"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LB",
     "wof:geomhash":"f1a91a9e621b954bd172b2e83550cbe8",
     "wof:hierarchy":[
@@ -76,7 +78,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884520,
     "wof:name":"Baalbek-Hermel",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/137/707/435/5/1377074355.geojson
+++ b/data/137/707/435/5/1377074355.geojson
@@ -72,8 +72,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"LB.NL",
+        "iso:code":"LB-AS",
         "iso:id":"LB-AS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LB",
     "wof:geomhash":"2b1ec6ab0f36ff4066ae9dbd26c7dd52",
     "wof:hierarchy":[
@@ -90,7 +92,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884520,
     "wof:name":"North Lebanon",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/137/707/435/7/1377074357.geojson
+++ b/data/137/707/435/7/1377074357.geojson
@@ -55,8 +55,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"LB.AA",
+        "iso:code":"LB-AK",
         "iso:id":"LB-AK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108691407
     ],
@@ -76,7 +78,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884520,
     "wof:name":"Akkar",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/421/171/405/421171405.geojson
+++ b/data/421/171/405/421171405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230046,
-    "geom:area_square_m":2355393159.053947,
+    "geom:area_square_m":2355393703.997992,
     "geom:bbox":"35.876683,33.812915,36.62372,34.450104",
     "geom:latitude":34.102577,
     "geom:longitude":36.263515,
@@ -157,12 +157,13 @@
         "qs_pg:id":1249401,
         "wd:id":"Q782804"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1459008892,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae3ae3081ee5904d0d49b9f43c9640ed",
+    "wof:geomhash":"e590055ad380a9276c9c318d05c6f9ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":421171405,
-    "wof:lastmodified":1690938517,
+    "wof:lastmodified":1695886594,
     "wof:name":"Baalbek",
     "wof:parent_id":1377074353,
     "wof:placetype":"county",

--- a/data/421/172/015/421172015.geojson
+++ b/data/421/172/015/421172015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033234,
-    "geom:area_square_m":340635857.082298,
+    "geom:area_square_m":340635648.788998,
     "geom:bbox":"35.596346,33.940144,35.96471,34.085073",
     "geom:latitude":34.012454,
     "geom:longitude":35.767753,
@@ -95,12 +95,13 @@
         "hasc:id":"LB.JL.KE",
         "qs_pg:id":1291276
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1459008916,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17c03330bdea8cf19baf43f5965239e4",
+    "wof:geomhash":"c433731996d2730286c0eadac84f6648",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421172015,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Kesrwane",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/172/017/421172017.geojson
+++ b/data/421/172/017/421172017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04269,
-    "geom:area_square_m":438583758.526224,
+    "geom:area_square_m":438583300.339817,
     "geom:bbox":"35.767494,33.682862,36.09397,33.934048",
     "geom:latitude":33.81268,
     "geom:longitude":35.927789,
@@ -161,12 +161,13 @@
         "qs_pg:id":1291278,
         "wd:id":"Q2484830"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1459008916,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61d8b1a547f00688d129a8d83f41a96f",
+    "wof:geomhash":"722e770318d202199aab944de5d5600c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":421172017,
-    "wof:lastmodified":1690938516,
+    "wof:lastmodified":1695886594,
     "wof:name":"Zahle",
     "wof:parent_id":1377074351,
     "wof:placetype":"county",

--- a/data/421/173/359/421173359.geojson
+++ b/data/421/173/359/421173359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042171,
-    "geom:area_square_m":434241621.456935,
+    "geom:area_square_m":434241601.405306,
     "geom:bbox":"35.604319,33.424165,35.939137,33.773938",
     "geom:latitude":33.616781,
     "geom:longitude":35.758894,
@@ -95,12 +95,13 @@
         "hasc:id":"LB.BQ.BW",
         "qs_pg:id":287612
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1459008980,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad959f7ed2c463d530f6c15b64955236",
+    "wof:geomhash":"9fc14fbf82ed6d8b1e6dd038d7799a16",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421173359,
-    "wof:lastmodified":1627522325,
+    "wof:lastmodified":1695886785,
     "wof:name":"West Bekaa",
     "wof:parent_id":1377074351,
     "wof:placetype":"county",

--- a/data/421/194/845/421194845.geojson
+++ b/data/421/194/845/421194845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041296,
-    "geom:area_square_m":422712362.013772,
+    "geom:area_square_m":422712134.894722,
     "geom:bbox":"35.627945,34.040229,36.017771,34.211799",
     "geom:latitude":34.123831,
     "geom:longitude":35.811183,
@@ -95,12 +95,13 @@
         "hasc:id":"LB.JL.JB",
         "qs_pg:id":9336
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1459009821,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0d473ffded0966cf361ccb21b0ab4dd5",
+    "wof:geomhash":"88a1b9d11123364962c8063f8e5e3e8f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421194845,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Jbeil",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/202/301/421202301.geojson
+++ b/data/421/202/301/421202301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019046,
-    "geom:area_square_m":195602694.995599,
+    "geom:area_square_m":195602694.995621,
     "geom:bbox":"35.4803773947,33.7946400355,35.8355955463,33.8901672767",
     "geom:latitude":33.843798,
     "geom:longitude":35.671934,
@@ -170,12 +170,13 @@
         "hasc:id":"LB.JL.BD",
         "qs_pg:id":220662
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1459010112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a5515d5cef62a94e133b41c9e84509ab",
+    "wof:geomhash":"df921c19922545b0bda7f5ad1dea1bda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421202301,
-    "wof:lastmodified":1582318498,
+    "wof:lastmodified":1695886595,
     "wof:name":"Baabda",
     "wof:parent_id":85673491,
     "wof:placetype":"county",

--- a/data/421/204/111/421204111.geojson
+++ b/data/421/204/111/421204111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027403,
-    "geom:area_square_m":280186439.205216,
+    "geom:area_square_m":280186105.050383,
     "geom:bbox":"35.647385,34.135677,36.031358,34.337949",
     "geom:latitude":34.220815,
     "geom:longitude":35.813503,
@@ -153,12 +153,13 @@
         "qs_pg:id":238183,
         "wd:id":"Q26781"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LB",
     "wof:created":1459010174,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8d2b0e8cbb076bbc21deb55fcb7a960",
+    "wof:geomhash":"6cdc34e11ec1a97887739d988d738f7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421204111,
-    "wof:lastmodified":1690938515,
+    "wof:lastmodified":1695886595,
     "wof:name":"El Batroun",
     "wof:parent_id":1377074355,
     "wof:placetype":"county",

--- a/data/856/325/33/85632533.geojson
+++ b/data/856/325/33/85632533.geojson
@@ -1225,6 +1225,7 @@
         "hasc:id":"LB",
         "icao:code":"OD",
         "ioc:id":"LIB",
+        "iso:code":"LB",
         "itu:id":"LBN",
         "loc:id":"n79090014",
         "m49:code":"422",
@@ -1239,6 +1240,7 @@
         "wk:page":"Lebanon",
         "wmo:id":"LB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LB",
     "wof:country_alpha3":"LBN",
     "wof:geom_alt":[
@@ -1262,7 +1264,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639596,
+    "wof:lastmodified":1695881257,
     "wof:name":"Lebanon",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/734/87/85673487.geojson
+++ b/data/856/734/87/85673487.geojson
@@ -575,9 +575,11 @@
         "gn:id":276780,
         "gp:id":2346016,
         "hasc:id":"LB.BA",
+        "iso:code":"LB-BA",
         "qs_pg:id":1135133,
         "unlc:id":"LB-BA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890442383
     ],
@@ -600,7 +602,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493125,
+    "wof:lastmodified":1695884281,
     "wof:name":"Beirut",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/91/85673491.geojson
+++ b/data/856/734/91/85673491.geojson
@@ -281,9 +281,11 @@
         "gn:id":273607,
         "gp:id":2346017,
         "hasc:id":"LB.JL",
+        "iso:code":"LB-JL",
         "qs_pg:id":1115650,
         "unlc:id":"LB-JL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LB",
     "wof:geom_alt":[
         "quattroshapes"
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493125,
+    "wof:lastmodified":1695884281,
     "wof:name":"Mount Lebanon",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/95/85673495.geojson
+++ b/data/856/734/95/85673495.geojson
@@ -209,8 +209,10 @@
         "gn:id":444191,
         "gp:id":56049597,
         "hasc:id":"LB.NA",
+        "iso:code":"LB-NA",
         "qs_pg:id":996715
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LB",
     "wof:geom_alt":[
         "quattroshapes"
@@ -230,7 +232,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884520,
     "wof:name":"Nabatieh",
     "wof:parent_id":85632533,
     "wof:placetype":"region",

--- a/data/856/734/99/85673499.geojson
+++ b/data/856/734/99/85673499.geojson
@@ -278,8 +278,10 @@
         "gn:id":279894,
         "gp:id":2346014,
         "hasc:id":"LB.JA",
+        "iso:code":"LB-JA",
         "qs_pg:id":1135131
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LB",
     "wof:geom_alt":[
         "quattroshapes"
@@ -299,7 +301,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493127,
+    "wof:lastmodified":1695884286,
     "wof:name":"South Lebanon",
     "wof:parent_id":85632533,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.